### PR TITLE
fix(tink): use v1.1 schema as default config

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -21,7 +21,7 @@ steps:
       - tag
 
 - name: build
-  image: rancher/dapper:v0.4.1
+  image: rancher/dapper:v0.6.0
   commands:
   - dapper ci
   volumes:

--- a/pkg/tink/tink.go
+++ b/pkg/tink/tink.go
@@ -31,11 +31,11 @@ func GenerateHWRequest(i *seederv1alpha1.Inventory, c *seederv1alpha1.Cluster) (
 	}
 
 	var m string
-	if strings.Contains(c.Spec.HarvesterVersion, "v1.1") {
-		m, err = generateMetaDataV11(c.Spec.ConfigURL, c.Spec.HarvesterVersion, i.Spec.ManagementInterfaceMacAddress, mode,
+	if strings.Contains(c.Spec.HarvesterVersion, "v1.0") {
+		m, err = generateMetaDataV10(c.Spec.ConfigURL, c.Spec.HarvesterVersion, i.Spec.ManagementInterfaceMacAddress, mode,
 			i.Spec.PrimaryDisk, c.Status.ClusterAddress, c.Status.ClusterToken, i.Status.GeneratedPassword, c.Spec.ImageURL, c.Spec.ClusterConfig.Nameservers, c.Spec.ClusterConfig.SSHKeys)
 	} else {
-		m, err = generateMetaDataV10(c.Spec.ConfigURL, c.Spec.HarvesterVersion, i.Spec.ManagementInterfaceMacAddress, mode,
+		m, err = generateMetaDataV11(c.Spec.ConfigURL, c.Spec.HarvesterVersion, i.Spec.ManagementInterfaceMacAddress, mode,
 			i.Spec.PrimaryDisk, c.Status.ClusterAddress, c.Status.ClusterToken, i.Status.GeneratedPassword, c.Spec.ImageURL, c.Spec.ClusterConfig.Nameservers, c.Spec.ClusterConfig.SSHKeys)
 	}
 	if err != nil {


### PR DESCRIPTION
For version like v1.2 or current master-head, they all need to use v1.1 metadata, so I change default schema as v1.1.