### PR TITLE
clean up node create/join mode condition

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,3 +1,19 @@
 set -e
 cd $(dirname $0)/..
+
+cleanup_containers() {
+for i in k3s-mock redfishmock
+do
+    if [ "$(docker ps -a -q -f name=${i})" ]; then
+        if [ "$(docker ps -aq -f status=running -f name=${i})" ]; then
+            docker stop ${i}
+        fi
+        if [ "$(docker ps -aq -f status=exited -f name=${i})" ]; then
+            docker rm -v ${i}
+        fi
+    fi
+done
+}
+
+cleanup_containers
 go test -coverprofile /tmp/cover.out -timeout=20m -p 1 -v ./...


### PR DESCRIPTION
Currently when an inventory is removed from a cluster on cluster deletion or resizing of cluster, the HarvesterJoinMode and HarvesterCreateMode conditions are not removed.

As a result if an inventory has been used in the past as the first node of a cluster, the HarvesterCreateMode condition is already present. In such a scenario, even though the node is not the first node, the tinkerbell hardware workflow sets this up as a pxe script with `harvester.install.mode` set to `create`. This can cause conflicts as another node in the cluster could have been booted with the same create config, which eventually results in address conflicts on the network.

The PR ensures that when an inventory is removed from a cluster, the CreateMode/JoinMode conditions are removed.