### PR TITLE
fix drone builds

### DIFF
--- a/.drone.yaml
+++ b/.drone.yaml
@@ -22,6 +22,8 @@ steps:
 
 - name: build
   image: rancher/dapper:v0.6.0
+  network_mode: host
+  privileged: true
   commands:
   - dapper ci
   volumes:


### PR DESCRIPTION
PR adds `network_mode` and `privileged` options to dapper builds

based on documentation: https://docs.drone.io/yaml/docker/#the-network_mode-attribute