### PR TITLE
go bump and metrics port fix

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM golang:1.22.7
+FROM golang:1.23
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
@@ -15,7 +15,7 @@ RUN apt update && \
     apt install -y bash git gcc docker.io vim less file curl wget ca-certificates qemu-utils
 
 ## install golangci
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.59.1
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.63.4
 
 # The docker version in dapper is too old to have buildx. Install it manually.
 RUN curl -sSfL https://github.com/docker/buildx/releases/download/v0.13.1/buildx-v0.13.1.linux-${ARCH} -o buildx-v0.13.1.linux-${ARCH} && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/seeder
 
-go 1.22.7
+go 1.23.4
 
 require (
 	github.com/go-bindata/go-bindata/v3 v3.1.3

--- a/pkg/controllers/setup.go
+++ b/pkg/controllers/setup.go
@@ -62,7 +62,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		Metrics: server.Options{
-			BindAddress: ":9080",
+			BindAddress: s.MetricsAddress,
 		},
 		HealthProbeBindAddress:  s.ProbeAddress,
 		LeaderElection:          s.EnableLeaderElection,

--- a/pkg/data/data.go
+++ b/pkg/data/data.go
@@ -182,7 +182,7 @@ func chartSeederCrdTemplatesBmcTinkerbellOrg_machinesYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "chart/seeder-crd/templates/bmc.tinkerbell.org_machines.yaml", size: 13020, mode: os.FileMode(420), modTime: time.Unix(1736896865, 0)}
+	info := bindataFileInfo{name: "chart/seeder-crd/templates/bmc.tinkerbell.org_machines.yaml", size: 13020, mode: os.FileMode(420), modTime: time.Unix(1737329731, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -222,7 +222,7 @@ func chartSeederCrdTemplatesMetalHarvesterhciIo_addresspoolsYaml() (*asset, erro
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "chart/seeder-crd/templates/metal.harvesterhci.io_addresspools.yaml", size: 3227, mode: os.FileMode(420), modTime: time.Unix(1736896865, 0)}
+	info := bindataFileInfo{name: "chart/seeder-crd/templates/metal.harvesterhci.io_addresspools.yaml", size: 3227, mode: os.FileMode(420), modTime: time.Unix(1737329731, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -242,7 +242,7 @@ func chartSeederCrdTemplatesMetalHarvesterhciIo_clustersYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "chart/seeder-crd/templates/metal.harvesterhci.io_clusters.yaml", size: 4750, mode: os.FileMode(420), modTime: time.Unix(1736896865, 0)}
+	info := bindataFileInfo{name: "chart/seeder-crd/templates/metal.harvesterhci.io_clusters.yaml", size: 4750, mode: os.FileMode(420), modTime: time.Unix(1737329731, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -262,7 +262,7 @@ func chartSeederCrdTemplatesMetalHarvesterhciIo_inventoriesYaml() (*asset, error
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "chart/seeder-crd/templates/metal.harvesterhci.io_inventories.yaml", size: 15658, mode: os.FileMode(420), modTime: time.Unix(1736896865, 0)}
+	info := bindataFileInfo{name: "chart/seeder-crd/templates/metal.harvesterhci.io_inventories.yaml", size: 15658, mode: os.FileMode(420), modTime: time.Unix(1737329731, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/util/conditions.go
+++ b/pkg/util/conditions.go
@@ -29,7 +29,7 @@ func CreateOrUpdateCondition(i *seederv1alpha1.Inventory, cond condition.Cond, m
 
 func SetErrorCondition(i *seederv1alpha1.Inventory, cond condition.Cond, message string) {
 	now := time.Now().UTC().Format(time.RFC3339)
-	cond.SetError(i, "", fmt.Errorf(message))
+	cond.SetError(i, "", fmt.Errorf("%s", message))
 	cond.True(i)
 	cond.LastUpdated(i, now)
 }


### PR DESCRIPTION
PR https://github.com/harvester/seeder/pull/21 introduced an error where the metrics port was hardcoded to 9080.

This caused the chart in harvester-seeder addon to fail when used with the new image since the health check would fail causing pod to be restarted.

The PR fixes the metrics port to be back to to the original port passed via the command line flags

The PR also bumps go to v1.23 and fixes a formatting error in conditions.go picked up by bump to linter.

Related issue: https://github.com/harvester/harvester/issues/7336