### PR TITLE
test: Add Test Checks Wipe Disks List

### DIFF
--- a/pkg/tink/testdata/customized-create.yaml
+++ b/pkg/tink/testdata/customized-create.yaml
@@ -1,0 +1,40 @@
+os:
+  persistentStatePaths:
+    - /var/lib/rook
+    - /var/lib/ceph
+    - /etc/ceph
+    - /etc/webhook
+  modules:
+    - rbd
+    - nbd
+  sshAuthorizedKeys:
+    - ssh-rsa blah test@test
+  ntpServers:
+    - time1.google.com
+    - time2.google.com
+    - time3.google.com
+    - time.cloudflare.com
+install:
+  mode: create
+  management_interface:
+    interfaces:
+      - name: ens5
+    default_route: true
+    method: dhcp
+    bond_options:
+      mode: balance-tlb
+      miimon: 100
+  device: /dev/nvme0n1 # The target disk to install
+  iso_url: https://releases.rancher.com/harvester/master/harvester-master-amd64.iso
+  #  tty: ttyS1,115200n8   # For machines without a VGA console
+  vip: 10.10.0.19
+  vip_mode: dhcp # Or static
+  vip_hw_addr: 52:54:00:ec:0e:0b # Leave empty when vip_mode is static
+  wipediskslist:
+    - /dev/vda
+    - /dev/nvme0n1
+    - /dev/sda
+    - /dev/sdb
+system_settings:
+  containerd-registry: '{"Mirrors":{"*":{"Endpoints":["https://registry.1.2.3.4.sslip.io:5000"],"Rewrites":null}},"Configs":{"registry.1.2.3.4.sslip.io:5000":{"Auth":null,"TLS":{"CAFile":"","CertFile":"","KeyFile":"","InsecureSkipVerify":true}}},"Auths":null}'
+  backup-target: '{"type":"s3","endpoint":"http://4.5.6.7:9000/","accessKeyId":"","secretAccessKey":"","bucketName":"test-bucket","bucketRegion":"us-east-1","cert":"","virtualHostedStyle":false,"refreshIntervalInSeconds":0}'

--- a/pkg/tink/tink_test.go
+++ b/pkg/tink/tink_test.go
@@ -62,6 +62,16 @@ func Test_joinModeCloudConfig(t *testing.T) {
 	assert.Contains(hc.WipeDisksList, "/dev/vda", "expected to find /dev/vda in wipeDisksList")
 }
 
+func Test_createModeCloudConfigCheckWipeDisksListWorksBecauseSpecClusterConfigWipeDisksDeprecated(t *testing.T) {
+	assert := require.New(t)
+	cloudConfig, err := generateCloudConfig("file:///testdata/customized-create.yaml", "", "", "", "", "", "", "", "", nil, nil, nil, "", "", "", "", "", false, false, 2021, "", "", "")
+	assert.NoError(err)
+	hc := config.NewHarvesterConfig()
+	err = yaml.Unmarshal([]byte(cloudConfig), hc)
+	assert.NoError(err)
+	assert.Len(hc.WipeDisksList, 4)
+}
+
 var (
 	i = &seederv1alpha1.Inventory{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
* we are adding more mock data and a test that checks the wipe disks list gets brought in correctly, we previously did not know that seeder needed to parse content as install.wipediskslist and thought rather, it was supposed to be install.wipe_disks_list , this test just adds baseline sanity to show that it is parsing now how we have configuration set for some internal systems that depend on seeders provisioning process

Resolves: investigation/seeder-unmarshalls-not-like-installer



