### PR TITLE
fix: Fixup Error Message

### DIFF
--- a/pkg/controllers/cluster_controller.go
+++ b/pkg/controllers/cluster_controller.go
@@ -627,7 +627,7 @@ func (r *ClusterReconciler) markClusterReady(ctx context.Context, cObj *seederv1
 	}
 
 	if len(nl.Items) != len(c.Spec.Nodes) {
-		return fmt.Errorf("api server is running, expected to find %d nodes but only found %d nodes", len(nl.Items), len(c.Spec.Nodes))
+		return fmt.Errorf("api server is running, expected to find %d nodes but only found %d nodes", len(c.Spec.Nodes), len(nl.Items))
 	}
 
 	c.Status.Status = seederv1alpha1.ClusterRunning


### PR DESCRIPTION
* as we start to embark on actually having more visibility into systems via logs, metrics, traces, & alerts - we've noticed that likely the error message needs to be updated for the message to make more sense as it's ingested into Loki or other places

Resolves: fix/fixup-error-message

### Example:

```json
{"level":"error","ts":"2026-05-06T19:19:28Z","msg":"Reconciler error","controller":"cluster","controllerGroup":"metal.harvesterhci.io","controllerKind":"Cluster","Cluster":{"name":"giants-tclgi","namespace":"tink-system"},"namespace":"tink-system","name":"giants-tclgi","reconcileID":"8e57d911-98aa-4f1c-a179-5ee1d6ebf216","error":"api server is running, expected to find 2 nodes but only found 3 nodes","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:474\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.5/pkg/internal/controller/controller.go:296"}
```

It can be noticed, that at the time on May 6th 2026, giants-* cluster it had "3" nodes included in the cluster manifest.
But the error that's bubbling up likely needs to have the numbers reversed to read something like:
```
expected to find 3 nodes but only found 2
```

^ which would make more sense.

This PR just flips the numbers around that get interpolated into the error message string - likely fixing the weirdness we were seeing with our logs.

As we likely will see more similar things with our systems, but the idea is we're trying to embark on actually having visibility with alerting / metrics / logs / (maybe future state traces) to our internal systems - to help us stay ahead of the curve vs. behind it - help us have more places for forensics as well when we run into issues.

cc: @harvester/qa 