### PR TITLE
chore: bump golang 1.26

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/golang:1.25.7
+FROM registry.suse.com/bci/golang:1.26
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH="$DAPPER_HOST_ARCH"
@@ -30,7 +30,7 @@ RUN export K8S_VERSION=v1.34.0 && \
 RUN zypper -n install bash git gcc docker vim less file curl wget ca-certificates docker-buildx
 
 ## install golangci
-RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
+RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
     
 ENV DAPPER_ENV="REPO TAG DRONE_TAG CROSS SKIPINDRONE"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/seeder
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/go-bindata/go-bindata/v3 v3.1.3


### PR DESCRIPTION
    - also bump golangci-lint 2.12.2

<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Problem:
bump golang 1.26

#### Solution:
bump golang 1.26

#### Related Issue(s):
https://github.com/harvester/harvester/issues/10734

#### Test plan:
<!-- Describe the test plan by steps. -->

#### Additional documentation or context
