### PR TITLE
chore: bump base image version as sles:15.6 is eol

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build the manager binary
 FROM registry.suse.com/bci/bci-base:16.0
-RUN zypper -n install ipmitool=1.8.18.238.gb7adc1d-150600.8.3 && zypper clean
+RUN zypper -n install ipmitool=1.8.19.13.gbe11d94-160000.3.1 && zypper clean
 ARG TARGETPLATFORM
 
 RUN if [ "$TARGETPLATFORM" != "linux/amd64" ] && [ "$TARGETPLATFORM" != "linux/arm64" ]; then \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.7.0
 
 # Build the manager binary
-FROM registry.suse.com/bci/bci-base:15.6
+FROM registry.suse.com/bci/bci-base:16.0
 RUN zypper -n install ipmitool=1.8.18.238.gb7adc1d-150600.8.3 && zypper clean
 ARG TARGETPLATFORM
 


### PR DESCRIPTION
<!-- 
!IMPORTANT!
Please do not create a Pull Request without creating an issue first
at https://github.com/harvester/harvester/issues/new/choose
-->

#### Changes:
<!-- Explain the problem you aim to resolve in this PR. -->

Bump base image to sles:16.0 as sles:15.6 is EOL.

#### Related Issue(s):
<!--
Use `Issue #<issue number>` or `Issue harvester/harvester#<issue number>` or `Issue (paste link of issue)`. DON'T use `Fixes #<issue number>` or `Fixes (paste link of issue)`, as it will automatically close the linked issue when the PR is merged.
-->

image-scanning/6171
image-scanning/10334

#### Test plan:
<!-- Describe the test plan by steps. -->

* Run local `make ci`
* GH CI

#### Additional documentation or context
