### PR TITLE
Publish images via harvester-actions registry actions

### DIFF
--- a/.github/workflows/template-build.yml
+++ b/.github/workflows/template-build.yml
@@ -11,7 +11,9 @@ on:
         required: true
         type: boolean
 env:
-  imageName: "rancher/harvester-seeder"
+  PLATFORMS: linux/amd64,linux/arm64
+  imageName: "harvester-seeder"
+  dockerfile: "package/Dockerfile"
 
 jobs:
   dapper-build:
@@ -39,27 +41,65 @@ jobs:
       - name: Run dapper
         run: make ci
 
-      - name: Read some Secrets
-        uses: rancher-eio/read-vault-secrets@d266f55186f80a893839f6e15662e67388e443e6 # v3
-        if: ${{ inputs.push == true }}
+      - name: Resolve registries
+        id: resolve
+        uses: harvester/harvester-actions/actions/resolve-registries@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
         with:
-          secrets: |
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
-            secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials password | DOCKER_PASSWORD
+          release-tag-name: ${{ inputs.release-tag-name }}
+          is-release: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+
+      - name: Set image tag
+        run: echo "IMAGE_TAG=${RELEASE_TAG_NAME#prime-}" >> "$GITHUB_ENV"
+        env:
+          RELEASE_TAG_NAME: ${{ inputs.release-tag-name }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
-        if: ${{ inputs.push == true }}
-        with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
+        id: login-docker
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-docker-io == 'true' }}
+        uses: harvester/harvester-actions/actions/login-docker-hub@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
 
-      - name: Docker Build
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      - name: Publish public ${{ env.imageName }} image
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-docker-io == 'true' }}
+        uses: harvester/harvester-actions/actions/publish-public-image@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
         with:
-          provenance: false
           context: .
-          platforms: linux/amd64,linux/arm64
-          file: package/Dockerfile
-          push: ${{ inputs.push }}
-          tags: ${{env.imageName}}:${{ inputs.release-tag-name }}
+          dockerfile: ${{ env.dockerfile }}
+          image: ${{ env.imageName }}
+          tag: ${{ env.IMAGE_TAG }}
+          platforms: ${{ env.PLATFORMS }}
+          registry: ${{ steps.login-docker.outputs.registry }}
+          repository: ${{ steps.login-docker.outputs.repository }}
+
+      - name: Login to Staging Registry
+        id: login-staging
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-staging == 'true' }}
+        uses: harvester/harvester-actions/actions/login-staging-registry@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+
+      - name: Publish staging ${{ env.imageName }} image
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-staging == 'true' }}
+        uses: harvester/harvester-actions/actions/publish-prime-image@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+        with:
+          context: .
+          dockerfile: ${{ env.dockerfile }}
+          image: ${{ env.imageName }}
+          tag: ${{ env.IMAGE_TAG }}
+          platforms: ${{ env.PLATFORMS }}
+          registry: ${{ steps.login-staging.outputs.registry }}
+          repository: ${{ steps.login-staging.outputs.repository }}
+
+      - name: Login to Prime Registry
+        id: login-prime
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-prime == 'true' }}
+        uses: harvester/harvester-actions/actions/login-prime-registry@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+
+      - name: Publish prime ${{ env.imageName }} image
+        if: ${{ inputs.push == true && steps.resolve.outputs.use-prime == 'true' }}
+        uses: harvester/harvester-actions/actions/publish-prime-image@a6fc1cfb81904c08e2267675fd5ac7b11a5092a9 # main
+        with:
+          context: .
+          dockerfile: ${{ env.dockerfile }}
+          image: ${{ env.imageName }}
+          tag: ${{ env.IMAGE_TAG }}
+          platforms: ${{ env.PLATFORMS }}
+          registry: ${{ steps.login-prime.outputs.registry }}
+          repository: ${{ steps.login-prime.outputs.repository }}


### PR DESCRIPTION
Use the shared harvester/harvester-actions actions so images are conditionally published to docker.io, the staging registry, and the prime registry.
  - Branch merge: push to the public and staging registries.
  - Tag (v*): push to the public registry.
  - Tag (`prime-*`): push to the prime registry.

note: need to refer to https://github.com/harvester/harvester-actions for actions

